### PR TITLE
revert naming of var HMCTS_CP_ADO_PAT to HMCTS_ADO_PAT

### DIFF
--- a/.github/workflows/ci-build-publish.yml
+++ b/.github/workflows/ci-build-publish.yml
@@ -7,7 +7,7 @@ on:
         required: true
       AZURE_DEVOPS_ARTIFACT_TOKEN:
         required: true
-      HMCTS_CP_ADO_PAT:
+      HMCTS_ADO_PAT:
         required: true
       PACT_BROKER_TOKEN:
         required: true
@@ -229,7 +229,7 @@ jobs:
         uses: hmcts/trigger-ado-pipeline@v1
         with:
           pipeline_id: 460
-          ado_pat: ${{ secrets.HMCTS_CP_ADO_PAT }}
+          ado_pat: ${{ secrets.HMCTS_ADO_PAT }}
           template_parameters: >
             {
               "GROUP_ID": "uk.gov.hmcts.cp",

--- a/.github/workflows/ci-draft.yml
+++ b/.github/workflows/ci-draft.yml
@@ -16,7 +16,7 @@ jobs:
     secrets:
       AZURE_DEVOPS_ARTIFACT_USERNAME: ${{ secrets.AZURE_DEVOPS_ARTIFACT_USERNAME }}
       AZURE_DEVOPS_ARTIFACT_TOKEN: ${{ secrets.AZURE_DEVOPS_ARTIFACT_TOKEN }}
-      HMCTS_CP_ADO_PAT: ${{ secrets.HMCTS_CP_ADO_PAT }}
+      HMCTS_ADO_PAT: ${{ secrets.HMCTS_CP_ADO_PAT }}
       PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
     with:
       is_publish: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci-released.yml
+++ b/.github/workflows/ci-released.yml
@@ -11,7 +11,7 @@ jobs:
     secrets:
       AZURE_DEVOPS_ARTIFACT_USERNAME: ${{ secrets.AZURE_DEVOPS_ARTIFACT_USERNAME }}
       AZURE_DEVOPS_ARTIFACT_TOKEN: ${{ secrets.AZURE_DEVOPS_ARTIFACT_TOKEN }}
-      HMCTS_CP_ADO_PAT: ${{ secrets.HMCTS_CP_ADO_PAT }}
+      HMCTS_ADO_PAT: ${{ secrets.HMCTS_CP_ADO_PAT }}
       PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
     with:
       is_release: true


### PR DESCRIPTION
The secret in used is CP specific but this should not be reflected in the param name