### PR TITLE
chore: exclude .claude worktrees from IDEA indexing

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -24,3 +24,10 @@ springBoot {
     }
   }
 }
+
+apply plugin: 'idea'
+idea {
+  module {
+    excludeDirs += file('.claude')
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `apply plugin: 'idea'` and excludes `.claude/` from IDEA module indexing in `gradle/java.gradle`
- Prevents Claude Code worktrees from polluting IDEA search results for everyone who checks out a repo generated from this template

## Test plan

- [ ] After Gradle sync in IDEA, `.claude/` folder shows as excluded (orange)
- [ ] Find in Files no longer returns results from `.claude/worktrees/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)