### PR TITLE
fix(security): pin tomcat-embed-core to 11.0.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,4 +45,8 @@ dependencies {
   // --- Observability / Actuator / OTEL / Prometheus ---
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
   implementation 'org.springframework.boot:spring-boot-starter-opentelemetry'
+
+  // Security: pin transitive tomcat-embed-core to patched version (CVE-2026-41293, -43512, et al.)
+  // Brought in transitively via spring-boot-starter-web; >=11.0.0-M1,<11.0.22 are vulnerable
+  implementation 'org.apache.tomcat.embed:tomcat-embed-core:11.0.22'
 }


### PR DESCRIPTION
Pins the transitive dependency org.apache.tomcat.embed:tomcat-embed-core to patched version 11.0.22. It is brought in via spring-boot-starter-web at 11.0.21, which is affected by multiple advisories (HTTP/2 header validation, DIGEST auth bypass, security constraints, WebDAV unbounded read, WebSocket auth header exposure, LockOutRealm case sensitivity, AJP timing). Fixes Dependabot alerts #54, #55, #56, #57, #58, #59, #60.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
