### PR TITLE
Add cucumber tests capability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,14 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
 
+  // BDD / acceptance tests — plain Cucumber on JUnit Platform + Spring (no Serenity)
+  testImplementation platform('io.cucumber:cucumber-bom:7.20.1')
+  testImplementation 'io.cucumber:cucumber-java'
+  testImplementation 'io.cucumber:cucumber-junit-platform-engine'
+  testImplementation 'io.cucumber:cucumber-spring'
+  // Gradle discovers tests by class, so the Cucumber engine needs a @Suite entry point to run
+  testImplementation 'org.junit.platform:junit-platform-suite'
+
 
   // --- Observability / Actuator / OTEL / Prometheus ---
   implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,0 +1,36 @@
+# Testing
+
+Four test categories. **Acceptance (BDD) is orthogonal to the unit/integration pyramid** — it is not a
+pyramid layer. All run under `./gradlew test`.
+
+| Category | Location / naming | Purpose |
+|---|---|---|
+| **Unit** | `*Test` in `src/test/java` | Pure logic, no Spring context |
+| **Integration / wiring** | `*IntegrationTest` in `…/integration/` | `@SpringBootTest` boundary tests; one context/sanity test also asserts actuator / technical-NFR behaviour |
+| **Acceptance / BDD** | `…/acceptance/` + `src/test/resources/features/` | Plain Cucumber on JUnit Platform + Spring (**no Serenity**); **business scenarios only** |
+
+## Acceptance (Cucumber) harness
+
+Shipped in this template — plain Cucumber, no Serenity:
+
+- **Dependencies** (`build.gradle`): `io.cucumber:cucumber-bom` (platform) + `cucumber-java`,
+  `cucumber-junit-platform-engine`, `cucumber-spring`, and `org.junit.platform:junit-platform-suite`.
+- **Runner** — `acceptance/AcceptanceTest` (`@Suite` + `@IncludeEngines("cucumber")` +
+  `@SelectClasspathResource("features")`). **Required for Gradle:** Gradle discovers tests by class, so
+  without this suite the Cucumber engine never runs. One suite runs every feature once — do not add a
+  second runner.
+- **Glue config** — `src/test/resources/junit-platform.properties`
+  (`cucumber.glue=uk.gov.hmcts.cp.acceptance`).
+- **Spring context** — `acceptance/CucumberSpringConfiguration` (`@CucumberContextConfiguration` +
+  `@SpringBootTest` + `@ActiveProfiles("test")`), same setup as the integration/sanity tests.
+- **Feature files** — `src/test/resources/features/*.feature`.
+- Delete the shipped `example.feature` + `ExampleStepDefinitions` once you add real scenarios.
+
+## Step-definition organisation (avoid the common Cucumber pitfalls)
+
+- **No 1:1 feature→step-def file.** Organise step defs by domain concept; reuse across features.
+- **Thin, low-complexity steps** — delegate to helpers/services; no `if`/`else`/loops or scenario logic
+  in glue (that cyclomatic complexity is the classic maintenance overhead).
+- **Share state via a Spring/Cucumber scenario-scoped bean**, never static fields.
+- **Declarative Gherkin** (business language); technical translation lives in the glue.
+- Prefer parameter types / data tables over regex-heavy steps; avoid conjunction ("And"-heavy) mega-steps.

--- a/src/test/java/uk/gov/hmcts/cp/acceptance/AcceptanceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/acceptance/AcceptanceTest.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.cp.acceptance;
+
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+/**
+ * JUnit-Platform suite that runs all Cucumber acceptance scenarios under
+ * {@code src/test/resources/features}, executed by {@code ./gradlew test}.
+ *
+ * <p>Named {@code AcceptanceTest} (ends in {@code Test}) so it is discovered by the {@code test} task
+ * regardless of any name filter, paralleling the integration convention {@code *IntegrationTest}.
+ *
+ * <p>Gradle discovers tests by class, so this suite is the entry point that hands the feature files to
+ * the Cucumber engine — without it the scenarios are silently skipped. Glue (step-definition package)
+ * is configured in {@code src/test/resources/junit-platform.properties}. Do not duplicate this into a
+ * second runner: one suite runs every feature once.
+ */
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features")
+public class AcceptanceTest {
+}

--- a/src/test/java/uk/gov/hmcts/cp/acceptance/CucumberSpringConfiguration.java
+++ b/src/test/java/uk/gov/hmcts/cp/acceptance/CucumberSpringConfiguration.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.cp.acceptance;
+
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Boots the Spring application context for Cucumber acceptance scenarios.
+ *
+ * <p>Uses the same {@code @SpringBootTest} + {@code test} profile setup as the integration/sanity
+ * tests so acceptance and sanity boot identically. All Cucumber code (this glue, the step
+ * definitions) lives in this {@code acceptance} package; discovery + glue are configured in
+ * {@code src/test/resources/junit-platform.properties}.
+ */
+@CucumberContextConfiguration
+@SpringBootTest
+@ActiveProfiles("test")
+public class CucumberSpringConfiguration {
+}

--- a/src/test/java/uk/gov/hmcts/cp/acceptance/ExampleStepDefinitions.java
+++ b/src/test/java/uk/gov/hmcts/cp/acceptance/ExampleStepDefinitions.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.cp.acceptance;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Example step definitions proving the Cucumber + Spring harness runs. Replace with real,
+ * domain-organised step definitions.
+ *
+ * <p>Keep step definitions thin and low-complexity: a step should delegate to a helper/service,
+ * not contain branching or scenario logic. Organise by domain concept and reuse across features —
+ * never one step-definition class per feature file. See docs/Testing.md.
+ */
+public class ExampleStepDefinitions {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Given("the service is running")
+    public void the_service_is_running() {
+        assertThat(applicationContext).isNotNull();
+    }
+
+    @Then("the Spring application context has initialised")
+    public void the_spring_application_context_has_initialised() {
+        assertThat(applicationContext.getBeanDefinitionCount()).isPositive();
+    }
+}

--- a/src/test/resources/features/example.feature
+++ b/src/test/resources/features/example.feature
@@ -1,0 +1,8 @@
+Feature: Service smoke (example acceptance)
+
+  A minimal, business-readable scenario proving the Cucumber + Spring harness runs.
+  Replace with real business scenarios and delete this example, like the other Example* samples.
+
+  Scenario: the service starts up
+    Given the service is running
+    Then the Spring application context has initialised

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+cucumber.glue=uk.gov.hmcts.cp.acceptance
+cucumber.plugin=pretty, summary


### PR DESCRIPTION
Adds a ready-to-use BDD/acceptance-test harness to the HMCTS Spring Boot service template so services scaffolded from it get business-scenario testing out of the box. Docs + test-scaffolding only — no production code, no changes to the main source set. 7 files, +128.

**What's added**

- build.gradle — testImplementation deps: io.cucumber:cucumber-bom (platform) + cucumber-java, cucumber-junit-platform-engine, cucumber-spring, and org.junit.platform:junit-platform-suite. Plain Cucumber, not Serenity.
- …/acceptance/ package (in the existing single test source set — mirrors the …/integration/ convention, no new source set):
  - AcceptanceTest — JUnit-Platform @Suite runner (@IncludeEngines("cucumber"), @SelectClasspathResource("features")). Required for Gradle, which discovers tests by class — without the suite the Cucumber engine never runs and scenarios are silently skipped. Named with the *Test suffix (parallels *IntegrationTest) so it's discovered under any name filter.
  - CucumberSpringConfiguration — @CucumberContextConfiguration + @SpringBootTest + @ActiveProfiles("test"); same boot setup as the integration/sanity tests.
  - ExampleStepDefinitions — example glue (delete alongside the other Example* samples).
- src/test/resources/features/example.feature — example business scenario.
- src/test/resources/junit-platform.properties — cucumber.glue=uk.gov.hmcts.cp.acceptance + cucumber.plugin=pretty, summary.
- docs/Testing.md — the four test categories, the acceptance-harness setup, and step-definition anti-patterns.

**Verification**

./gradlew test → BUILD SUCCESSFUL; the example scenario runs and passes, in the standard test task (no new source set). Confirmed on Spring Boot 4.1 / Java 25 / Cucumber 7.20.1.

**Usage**

Delete the shipped example.feature + ExampleStepDefinitions once real scenarios are added; keep AcceptanceTest and CucumberSpringConfiguration as the harness.